### PR TITLE
get Berp to build with ghc 7.8.3 / base 4.7.0.1

### DIFF
--- a/compiler/berpcompiler.cabal
+++ b/compiler/berpcompiler.cabal
@@ -18,7 +18,7 @@ maintainer:          florbitous@gmail.com
 homepage:            http://wiki.github.com/bjpop/berp/
 build-type:          Simple
 stability:           experimental
-tested-with:         GHC==7.8.3
+tested-with:         GHC==7.4.1, GHC==7.6.3, GHC==7.8.3, GHC==7.10.1
 
 Executable berp
   ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-orphans

--- a/compiler/berpcompiler.cabal
+++ b/compiler/berpcompiler.cabal
@@ -34,7 +34,7 @@ Executable berp
       language-python,
       haskell-src-exts,
       filepath,
-      process == 1.0.*,
+      process >= 1.0 && < 1.3,
       parseargs,
       directory,
       berplibs == 0.0.3

--- a/compiler/berpcompiler.cabal
+++ b/compiler/berpcompiler.cabal
@@ -18,7 +18,7 @@ maintainer:          florbitous@gmail.com
 homepage:            http://wiki.github.com/bjpop/berp/
 build-type:          Simple
 stability:           experimental
-tested-with:         GHC==7.0.3
+tested-with:         GHC==7.8.3
 
 Executable berp
   ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-orphans

--- a/interpreter/berpinterpreter.cabal
+++ b/interpreter/berpinterpreter.cabal
@@ -16,7 +16,7 @@ maintainer:          florbitous@gmail.com
 homepage:            http://wiki.github.com/bjpop/berp/
 build-type:          Simple
 stability:           experimental
-tested-with:         GHC==7.0.3
+tested-with:         GHC==7.6.3, GHC==7.8.3, GHC==7.10.1
 
 Executable berpi
   ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-orphans
@@ -32,13 +32,11 @@ Executable berpi
       language-python,
       haskell-src-exts,
       filepath,
-      process == 1.0.*,
       parseargs,
       directory,
       berplibs == 0.0.3,
-      hint == 0.3.3.*,
-      MonadCatchIO-mtl == 0.3.0.*,
-      haskeline == 0.6.4.*
+      hint >= 0.3.3 && < 0.5,
+      haskeline >= 0.6.4 && < 0.8
   other-modules:
       Berp.Interpreter.Input
       Berp.Interpreter.Monad

--- a/interpreter/src/Berp/Interpreter/Input.hs
+++ b/interpreter/src/Berp/Interpreter/Input.hs
@@ -60,12 +60,11 @@ isComment (CommentToken {}) = True
 isComment _other = False
 
 lastTokenIsColon :: [Token] -> Bool
-lastTokenIsColon [] = False
-lastTokenIsColon tokens =
-   isColon $ last tokens
+lastTokenIsColon = isColon . reverse
    where
-   isColon :: Token -> Bool
-   isColon (ColonToken {}) = True
+   isColon :: [Token] -> Bool
+   isColon (ColonToken {}:_) = True
+   isColon (NewlineToken {}:xs) = isColon xs
    isColon _other = False
 
 nonEmptyParenStack :: ParseState -> Bool

--- a/interpreter/src/Berp/Interpreter/Monad.hs
+++ b/interpreter/src/Berp/Interpreter/Monad.hs
@@ -15,7 +15,7 @@ module Berp.Interpreter.Monad (Repl, runRepl, withInputState, getGlobalScope) wh
 
 import Control.Monad.Trans as Trans (lift, liftIO)
 import Control.Monad.State.Strict as State (StateT (..), evalStateT, gets)
-import Control.Monad.CatchIO as CatchIO (MonadCatchIO (..))
+-- import Control.Monad.CatchIO as CatchIO (MonadCatchIO (..))
 import Language.Haskell.Interpreter (InterpreterT, runInterpreter)
 import System.Console.Haskeline as Haskeline (defaultSettings)
 import System.Console.Haskeline.IO (initializeInput, InputState)

--- a/libs/berplibs.cabal
+++ b/libs/berplibs.cabal
@@ -32,9 +32,9 @@ Library
       mtl == 2.*,
       containers,
       array >= 0.3 && < 0.6,
+      exceptions >= 0.6.1 && < 0.9,
       extensible-exceptions == 0.1.*,
       filepath,
-      MonadCatchIO-mtl >= 0.3.0 && < 0.3.2,
       haskell-src-exts == 1.11.*,
       language-python >= 0.3 && < 0.5,
       directory >= 1.1.0 && < 1.3

--- a/libs/berplibs.cabal
+++ b/libs/berplibs.cabal
@@ -35,7 +35,7 @@ Library
       exceptions >= 0.6.1 && < 0.9,
       extensible-exceptions == 0.1.*,
       filepath,
-      haskell-src-exts >= 1.11 && < 1.17,
+      haskell-src-exts >= 1.11 && < 1.18,
       language-python >= 0.3 && < 0.6,
       directory >= 1.1.0 && < 1.3
    exposed-modules:

--- a/libs/berplibs.cabal
+++ b/libs/berplibs.cabal
@@ -35,7 +35,7 @@ Library
       exceptions >= 0.6.1 && < 0.9,
       extensible-exceptions == 0.1.*,
       filepath,
-      haskell-src-exts == 1.11.*,
+      haskell-src-exts >= 1.11 && < 1.17,
       language-python >= 0.3 && < 0.5,
       directory >= 1.1.0 && < 1.3
    exposed-modules:

--- a/libs/berplibs.cabal
+++ b/libs/berplibs.cabal
@@ -18,7 +18,7 @@ maintainer:          florbitous@gmail.com
 homepage:            http://wiki.github.com/bjpop/berp/
 build-type:          Simple
 stability:           experimental
-tested-with:         GHC==7.0.3
+tested-with:         GHC==7.8.3
 extra-source-files:  src/include/BerpDebug.h
 
 Library

--- a/libs/berplibs.cabal
+++ b/libs/berplibs.cabal
@@ -36,7 +36,7 @@ Library
       extensible-exceptions == 0.1.*,
       filepath,
       haskell-src-exts >= 1.11 && < 1.17,
-      language-python >= 0.3 && < 0.5,
+      language-python >= 0.3 && < 0.6,
       directory >= 1.1.0 && < 1.3
    exposed-modules:
       Berp.Base

--- a/libs/berplibs.cabal
+++ b/libs/berplibs.cabal
@@ -31,13 +31,13 @@ Library
       base == 4.*,
       mtl == 2.*,
       containers,
-      array < 0.4,
+      array >= 0.3 && < 0.6,
       extensible-exceptions == 0.1.*,
       filepath,
-      MonadCatchIO-mtl == 0.3.0.*,
+      MonadCatchIO-mtl >= 0.3.0 && < 0.3.2,
       haskell-src-exts == 1.11.*,
-      language-python == 0.3.*,
-      directory == 1.1.0.*
+      language-python >= 0.3 && < 0.5,
+      directory >= 1.1.0 && < 1.3
    exposed-modules:
       Berp.Base
       Berp.Base.HashTable
@@ -65,6 +65,7 @@ Library
       Berp.Base.HashSet
       Berp.Base.Ident
       Berp.Base.Identity
+      Berp.Base.LegacyHash
       Berp.Base.LiftedIO
       Berp.Base.Mangle
       Berp.Base.Monad

--- a/libs/berplibs.cabal
+++ b/libs/berplibs.cabal
@@ -18,7 +18,7 @@ maintainer:          florbitous@gmail.com
 homepage:            http://wiki.github.com/bjpop/berp/
 build-type:          Simple
 stability:           experimental
-tested-with:         GHC==7.8.3
+tested-with:         GHC==7.4.1, GHC==7.6.3, GHC==7.8.3, GHC==7.10.1
 extra-source-files:  src/include/BerpDebug.h
 
 Library

--- a/libs/src/Berp/Base/Hash.hs
+++ b/libs/src/Berp/Base/Hash.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MagicHash, TypeSynonymInstances #-}
+{-# LANGUAGE MagicHash, TypeSynonymInstances, FlexibleInstances #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -16,7 +16,7 @@
 module Berp.Base.Hash (Hash (..), Hashed, hashedStr) where
 
 import Berp.Base.Mangle (mangle)
-import Data.HashTable as HT (hashString)
+import Berp.Base.LegacyHash as HT (hashString)
 
 type Hashed a = (Int, a)
 

--- a/libs/src/Berp/Base/LegacyHash.hs
+++ b/libs/src/Berp/Base/LegacyHash.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE Trustworthy #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Berp.Base.LegacyHash
+-- Copyright   :  (c) The University of Glasgow 2003
+-- License     :  BSD-style (see the file libraries/base/LICENSE)
+--
+-- Maintainer  :  libraries@haskell.org
+-- Stability   :  provisional
+-- Portability :  portable
+--
+-- Ported hashString from base-4.6.0.0, since it is not included in
+-- the more recent base libraries.
+--
+-----------------------------------------------------------------------------
+
+module Berp.Base.LegacyHash (hashString) where
+
+import Data.Bits (shiftR)
+import Data.Char (ord)
+import Data.List (foldl')
+import Data.Int (Int32, Int64)
+
+-- | A sample hash function for Strings.  We keep multiplying by the
+-- golden ratio and adding.  The implementation is:
+--
+-- > hashString = foldl' f golden
+-- >   where f m c = fromIntegral (ord c) * magic + hashInt32 m
+-- >         magic = 0xdeadbeef
+--
+-- Where hashInt32 works just as hashInt shown above.
+--
+-- Knuth argues that repeated multiplication by the golden ratio
+-- will minimize gaps in the hash space, and thus it's a good choice
+-- for combining together multiple keys to form one.
+--
+-- Here we know that individual characters c are often small, and this
+-- produces frequent collisions if we use ord c alone.  A
+-- particular problem are the shorter low ASCII and ISO-8859-1
+-- character strings.  We pre-multiply by a magic twiddle factor to
+-- obtain a good distribution.  In fact, given the following test:
+--
+-- > testp :: Int32 -> Int
+-- > testp k = (n - ) . length . group . sort . map hs . take n $ ls
+-- >   where ls = [] : [c : l | l <- ls, c <- ['\0'..'\xff']]
+-- >         hs = foldl' f golden
+-- >         f m c = fromIntegral (ord c) * k + hashInt32 m
+-- >         n = 100000
+--
+-- We discover that testp magic = 0.
+
+hashString :: String -> Int32
+hashString = foldl' f golden
+   where f m c = fromIntegral (ord c) * magic + hashInt32 m
+         magic = 0xdeadbeef
+
+golden :: Int32
+golden = 1013904242 -- = round ((sqrt 5 - 1) * 2^32) :: Int32
+-- was -1640531527 = round ((sqrt 5 - 1) * 2^31) :: Int32
+-- but that has bad mulHi properties (even adding 2^32 to get its inverse)
+-- Whereas the above works well and contains no hash duplications for
+-- [-32767..65536]
+
+-- | A sample (and useful) hash function for Int and Int32,
+-- implemented by extracting the uppermost 32 bits of the 64-bit
+-- result of multiplying by a 33-bit constant.  The constant is from
+-- Knuth, derived from the golden ratio:
+--
+-- > golden = round ((sqrt 5 - 1) * 2^32)
+--
+-- We get good key uniqueness on small inputs
+-- (a problem with previous versions):
+--  (length $ group $ sort $ map hashInt [-32767..65536]) == 65536 + 32768
+--
+hashInt32 :: Int32 -> Int32
+hashInt32 x = mulHi x golden + x
+
+-- hi 32 bits of a x-bit * 32 bit -> 64-bit multiply
+mulHi :: Int32 -> Int32 -> Int32
+mulHi a b = fromIntegral (r `shiftR` 32)
+   where r :: Int64
+         r = fromIntegral a * fromIntegral b

--- a/libs/src/Berp/Base/LegacyHash.hs
+++ b/libs/src/Berp/Base/LegacyHash.hs
@@ -5,9 +5,9 @@
 -- |
 -- Module      :  Berp.Base.LegacyHash
 -- Copyright   :  (c) The University of Glasgow 2003
--- License     :  BSD-style (see the file libraries/base/LICENSE)
+-- License     :  See the GHC license below.
 --
--- Maintainer  :  libraries@haskell.org
+-- Maintainer  :  (of this branch) florbitous@gmail.com
 -- Stability   :  provisional
 -- Portability :  portable
 --
@@ -15,6 +15,40 @@
 -- the more recent base libraries.
 --
 -----------------------------------------------------------------------------
+
+{-
+The Glasgow Haskell Compiler License
+
+Copyright 2004, The University Court of the University of Glasgow.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+- Neither name of the University nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY COURT OF THE UNIVERSITY OF
+GLASGOW AND THE CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+UNIVERSITY COURT OF THE UNIVERSITY OF GLASGOW OR THE CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+-}
 
 module Berp.Base.LegacyHash (hashString) where
 

--- a/libs/src/Berp/Base/Operators.hs
+++ b/libs/src/Berp/Base/Operators.hs
@@ -301,7 +301,7 @@ mulComplexFloatComplex = specialiseOpComplexFloatComplex (Prelude.*)
       _other -> raise typeError
 (*) x y = binop specialMulName x y
 
-checkDivByZero :: Num a => a -> Eval Object -> Eval Object
+checkDivByZero :: (Num a, Eq a) => a -> Eval Object -> Eval Object
 checkDivByZero denom comp
    | denom Prelude.== 0 = raise zeroDivisionError
    | otherwise = comp

--- a/libs/src/Berp/Base/SemanticTypes.hs
+++ b/libs/src/Berp/Base/SemanticTypes.hs
@@ -18,7 +18,10 @@
 module Berp.Base.SemanticTypes
    ( Procedure, ControlStack (..), EvalState (..), Object (..), Eval, ObjectRef
    , HashTable, HashSet, ListArray, Arity, ModuleCache
-   , initState )  where
+   , initState
+     -- re-exports needed for interpreter (due to the type of Eval)
+   , StateT, ContT, IO
+   )  where
 
 import Data.Typeable (Typeable)
 import Control.Monad.State.Strict (StateT)

--- a/libs/src/Berp/Compile/Compile.hs
+++ b/libs/src/Berp/Compile/Compile.hs
@@ -67,7 +67,7 @@ get_comp_expr = comprehension_expr
 
 #endif
 
-#if MIN_VERSION_haskell_src_exts(1,16,0)
+#if MIN_VERSION_haskell_src_exts(1,16,0) && !MIN_VERSION_haskell_src_exts(1,17,0)
 ns :: (Namespace -> a -> b) -> a -> b
 ns f = f NoNamespace
 #else

--- a/libs/src/Berp/Compile/Compile.hs
+++ b/libs/src/Berp/Compile/Compile.hs
@@ -38,6 +38,35 @@ import Berp.Compile.IdentString (IdentString (..), ToIdentString (..), identStri
 import Berp.Compile.Scope as Scope (Scope (..), topBindings, funBindings)
 import qualified Berp.Compile.Scope as Scope (isGlobal)
 
+yieldToMaybeExpr :: ExprSpan -> Maybe ExprSpan
+pairsFromDict :: [DictMappingPairSpan] -> [(ExprSpan, ExprSpan)]
+get_comp_expr :: ComprehensionSpanCompat -> ExprSpan
+
+#if MIN_VERSION_language_python(0,5,0)
+
+type ComprehensionSpanCompat = ComprehensionSpan
+
+yieldToMaybeExpr = fmap unYarg . yield_arg
+  where unYarg (YieldExpr e) = e
+        unYarg y = unsupported $ prettyText y
+
+pairsFromDict = map p2d
+  where p2d (DictMappingPair x y) = (x, y)
+
+get_comp_expr = f . comprehension_expr
+  where f (ComprehensionExpr e) = e
+        f (ComprehensionDict _) =
+              error "get_comp_expr called on ComprehensionDict"
+
+#else
+
+type ComprehensionSpanCompat = ComprehensionSpan ExprSpan
+yieldToMaybeExpr = yield_expr
+pairsFromDict = id
+get_comp_expr = comprehension_expr
+
+#endif
+
 #if MIN_VERSION_haskell_src_exts(1,16,0)
 ns :: (Namespace -> a -> b) -> a -> b
 ns f = f NoNamespace
@@ -397,12 +426,21 @@ instance Compilable ExprSpan where
    compile (Py.Var { var_ident = ident}) = do
       readExp <- compileRead ident
       return ([], readExp)
+#if MIN_VERSION_language_python(0,5,0)
+   compile (Py.Dot { dot_expr = leftExp, dot_attribute = method }) = do
+      (leftStmts, compiledLeft) <- compileExprObject leftExp
+      compiledMethod <- compile method
+      let newExp = infixApp compiledLeft (Prim.primOp ".") compiledMethod
+      return (leftStmts, newExp)
+#endif
    compile (Py.BinaryOp { operator = op, left_op_arg = leftExp, right_op_arg = rightExp })
+#if !MIN_VERSION_language_python(0,5,0)
       | Dot {} <- op, Py.Var { var_ident = method } <- rightExp = do
            (leftStmts, compiledLeft) <- compileExprObject leftExp
            compiledMethod <- compile method
            let newExp = infixApp compiledLeft (Prim.opExp op) compiledMethod
            return (leftStmts, newExp)
+#endif
       | otherwise = do
            (leftStmts, compiledLeft) <- compileExprObject leftExp
            (rightStmts, compiledRight) <- compileExprObject rightExp
@@ -436,7 +474,7 @@ instance Compilable ExprSpan where
              (stmts1, compiledE1) <- compileExprObject e1
              (stmts2, compiledE2) <- compileExprObject e2
              return (stmts1 ++ stmts2, (compiledE1, compiledE2))
-      (stmtss, exprPairs) <- mapAndUnzipM compileExprObjectPair mappings
+      (stmtss, exprPairs) <- mapAndUnzipM compileExprObjectPair $ pairsFromDict mappings
       let newExp = app Prim.dict $ listE $ map (\(x,y) -> Hask.tuple [x,y]) exprPairs
       return (concat stmtss, newExp)
    compile (Py.Set { set_exprs = elements }) = do
@@ -447,7 +485,8 @@ instance Compilable ExprSpan where
       (stmtss, exprs) <- mapAndUnzipM compileExprObject [obj_expr, sub]
       let newExp = appFun Prim.subscript exprs
       return (concat stmtss, newExp)
-   compile (Yield { yield_expr = maybeExpr }) = do
+   compile (y@Yield {}) = do
+      let maybeExpr = yieldToMaybeExpr y
       (stmts, compiledExpr) <- maybe (returnExp Prim.none) compileExprObject maybeExpr
       let newExpr = app Prim.yield $ parens compiledExpr
       setSeenYield True
@@ -466,13 +505,24 @@ data ComprehensType = GenComprehension | ListComprehension | DictComprehension |
 
 -- XXX maybe it would make more sense if we normalised dict comprehensions in the parser.
 -- could simplify the types somewhat.
+#if MIN_VERSION_language_python(0,5,0)
+normaliseDictComprehension :: ComprehensionSpan -> ComprehensionSpan
+normaliseDictComprehension comp@(Comprehension {
+                                    comprehension_expr =
+                                       ComprehensionDict (DictMappingPair e1 e2)
+                                    })
+   = comp { comprehension_expr = ComprehensionExpr $ Py.tuple [e1, e2] }
+normaliseDictComprehension _ =
+  error "normaliseDictComprehension called with non-ComprehensionDict"
+#else
 normaliseDictComprehension :: ComprehensionSpan (ExprSpan, ExprSpan) -> ComprehensionSpan ExprSpan
 normaliseDictComprehension comp@(Comprehension { comprehension_expr = (e1, e2) })
    = comp { comprehension_expr = Py.tuple [e1, e2] }
+#endif
 
-compileComprehens :: ComprehensType -> ComprehensionSpan ExprSpan -> Compile ([Stmt], Exp)
+compileComprehens :: ComprehensType -> ComprehensionSpanCompat -> Compile ([Stmt], Exp)
 compileComprehens GenComprehension comprehension = do
-   let resultStmt = stmtExpr $ yield $ comprehension_expr comprehension
+   let resultStmt = stmtExpr $ yield $ get_comp_expr comprehension
    desugaredFor <- desugarComprehensFor resultStmt $ comprehension_for comprehension
    bindings <- checkEither $ funBindings [] desugaredFor
    compiledBody <- nestedScope bindings $ compileBlockDo $ Block [desugaredFor]
@@ -483,7 +533,7 @@ compileComprehens ty comprehension = do
    v <- freshPythonVar
    let newVar = Py.var v
    let initStmt = comprehensInit ty newVar
-       resultStmt = comprehensUpdater ty newVar $ comprehension_expr comprehension
+       resultStmt = comprehensUpdater ty newVar $ get_comp_expr comprehension
    desugaredFor <- desugarComprehensFor resultStmt $ comprehension_for comprehension
    bindings <- checkEither $ funBindings [] desugaredFor
    let oldLocals = localVars bindings
@@ -501,9 +551,9 @@ comprehensInit GenComprehension _var = error $ "comprehensInit called on generat
 
 comprehensUpdater :: ComprehensType -> ExprSpan -> ExprSpan -> StatementSpan
 comprehensUpdater ListComprehension lhs rhs =
-   stmtExpr $ call (binOp dot lhs $ Py.var $ ident "append") [rhs]
+   stmtExpr $ call (dot lhs $ ident "append") [rhs]
 comprehensUpdater SetComprehension lhs rhs =
-   stmtExpr $ call (binOp dot lhs $ Py.var $ ident "add") [rhs]
+   stmtExpr $ call (dot lhs $ ident "add") [rhs]
 comprehensUpdater DictComprehension lhs (Py.Tuple { tuple_exprs = [key, val] }) =
    assign (subscript lhs key) val
 comprehensUpdater GenComprehension _lhs _rhs =
@@ -625,10 +675,16 @@ compileAssign (Py.Tuple { tuple_exprs = patElements }) rhs =
 compileAssign (Py.List { list_exprs = patElements }) rhs =
    compileUnpack patElements rhs
 -- Right argument of dot is always a variable, because dot associates to the left
+#if MIN_VERSION_language_python(0,5,0)
+compileAssign (Py.Dot { dot_expr = lhs
+                      , dot_attribute = attribute }
+              ) rhs = do
+#else
 compileAssign (Py.BinaryOp { operator = Dot {}
                            , left_op_arg = lhs
                            , right_op_arg = Py.Var { var_ident = attribute}}
               ) rhs = do
+#endif
    (stmtsLhs, compiledLhs) <- compileExprObject lhs
    compiledAttribute <- compile attribute
    let newStmt = qualStmt $ appFun Prim.setAttr [compiledLhs, compiledAttribute, rhs]

--- a/libs/src/Berp/Compile/IdentString.hs
+++ b/libs/src/Berp/Compile/IdentString.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
 
 -----------------------------------------------------------------------------
 -- |

--- a/libs/src/Berp/Compile/Monad.hs
+++ b/libs/src/Berp/Compile/Monad.hs
@@ -30,7 +30,8 @@ import Control.Applicative hiding (empty)
 -- import qualified MonadUtils (MonadIO (..))
 -- import Exception (ExceptionMonad (..))
 -- import Control.Exception.Extensible (block, unblock, catch)
-import Control.Monad.CatchIO as CatchIO (MonadCatchIO (..))
+-- import Control.Monad.CatchIO as CatchIO (MonadCatchIO (..))
+import Control.Monad.Catch (MonadThrow, MonadMask, MonadCatch)
 import qualified Data.Set as Set (Set, insert, empty)
 import Berp.Compile.Scope (Scope (..), emptyScope)
 
@@ -78,7 +79,8 @@ initState
 newtype Compile a
    = Compile (StateT State IO a)
    -- deriving (Monad, Functor, MonadIO, ExceptionMonad, Applicative)
-   deriving (Monad, Functor, MonadIO, Applicative, MonadCatchIO)
+   deriving (Monad, Functor, MonadIO, Applicative, -- MonadCatchIO,
+             MonadThrow, MonadCatch, MonadMask)
 
 -- the MonadState instance can't be derived by GHC
 -- because we're using the monads-tf (type families), and they 
@@ -86,13 +88,13 @@ newtype Compile a
 
 -- annoyingly the CatchIO module does not define this instance for the strict
 -- state monad, only the lazy one.
-#if !MIN_VERSION_MonadCatchIO_mtl(0,3,1)
+{-
 instance MonadCatchIO m => MonadCatchIO (StateT s m) where
     m `catch` f = StateT $ \s -> (runStateT m s)
                                    `CatchIO.catch` (\e -> runStateT (f e) s)
     block       = mapStateT block
     unblock     = mapStateT unblock
-#endif
+-}
 
 instance MonadState State Compile where
    -- type (StateType Compile) = State

--- a/libs/src/Berp/Compile/Monad.hs
+++ b/libs/src/Berp/Compile/Monad.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving, FlexibleInstances, MultiParamTypeClasses #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, FlexibleInstances, MultiParamTypeClasses, CPP #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -15,7 +15,9 @@
 
 module Berp.Compile.Monad where
 
+#if !MIN_VERSION_base(4,6,0)
 import Prelude hiding (catch)
+#endif
 import Control.Monad.State.Strict as State hiding (State)
 -- import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.State.Class (MonadState (..))
@@ -84,11 +86,13 @@ newtype Compile a
 
 -- annoyingly the CatchIO module does not define this instance for the strict
 -- state monad, only the lazy one.
+#if !MIN_VERSION_MonadCatchIO_mtl(0,3,1)
 instance MonadCatchIO m => MonadCatchIO (StateT s m) where
     m `catch` f = StateT $ \s -> (runStateT m s)
                                    `CatchIO.catch` (\e -> runStateT (f e) s)
     block       = mapStateT block
     unblock     = mapStateT unblock
+#endif
 
 instance MonadState State Compile where
    -- type (StateType Compile) = State

--- a/libs/src/Berp/Compile/PrimName.hs
+++ b/libs/src/Berp/Compile/PrimName.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      : Berp.Compile.PrimName
@@ -271,5 +273,7 @@ opExp (Divide {}) = primOp "/"
 opExp (FloorDivide {}) = primOp "//"
 opExp (Invert {}) = primOp "~" 
 opExp (Modulo {}) = primOp "%"
+#if !MIN_VERSION_language_python(0,5,0)
 opExp (Dot {}) = primOp "."
+#endif
 opExp other = unsupported $ "opExp: " ++ show other

--- a/libs/src/Berp/Compile/Scope.hs
+++ b/libs/src/Berp/Compile/Scope.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      : Berp.Compile.Scope
@@ -27,7 +27,7 @@ module Berp.Compile.Scope
 import Language.Python.Common.AST as Py
 import Data.Set as Set
 import Berp.Compile.IdentString (IdentString, ToIdentString (..), IdentString (..))
-import Data.List (intersperse, foldl')
+import qualified Data.List as L (intersperse, foldl')
 import Data.Monoid
 import Berp.Compile.PySyntaxUtils (varToString, paramIdent)
 
@@ -78,7 +78,7 @@ type VarSet = Set IdentString
 -- Collect all the variables which are assigned to in a list of expressions (patterns).
 -- XXX Incomplete
 assignTargets :: [ExprSpan] -> VarSet
-assignTargets = foldl' addTarget mempty
+assignTargets = L.foldl' addTarget mempty
    where
    addTarget :: VarSet -> ExprSpan -> VarSet
    addTarget set expr = Set.union (exprVars expr) set
@@ -149,7 +149,7 @@ allDisjoint params nonlocals globals
    ns_gs = nonlocals `Set.intersection` globals
 
 prettyVarSet :: VarSet -> String
-prettyVarSet = concat . intersperse "," . Prelude.map fromIdentString . Set.toList
+prettyVarSet = concat . L.intersperse "," . Prelude.map fromIdentString . Set.toList
 
 data BindingSets =
    BindingSets


### PR DESCRIPTION
This is my attempt at getting Berp to build with ghc 7.8.3.  (Issue #9)

This attempt was mostly successful, but there are some caveats:
- I've tried to avoid breaking older versions, but since I've only built with ghc 7.8.3, I can't say that with certainty.
- Likewise, I haven't tried ghc 7.10.  Since there are big changes in base 4.8, I suspect more work will be necessary before it will build with ghc 7.10.
- I only ported the "berplibs" and "berpcompiler" packages.  I ran into a lot of trouble with the "berpinterpreter" package, regarding changes in Typeable that I didn't know how to fix, so I left berpinterpreter alone.
- It builds with lots of warnings, including some deprecation warnings.
- It's still using old versions of language-python and haskell-src-exts.  More work will be necessary to bring it up to the latest versions of those packages.
- There are four failures in the test suite.  Since the README says "Don't worry if some tests fail", perhaps they were already broken?  They don't seem to be obviously related to anything I changed.  Since I'm not aware of a better way to attach a file to a GitHub issue, I've put the output of the test suite [in a gist](https://gist.github.com/ppelleti/31bae3df2c03b0dea774).
